### PR TITLE
Update script.py

### DIFF
--- a/cryptotools/BTC/script.py
+++ b/cryptotools/BTC/script.py
@@ -397,7 +397,7 @@ class VM:
                 valid = sig.verify_hash(sighash, pub)
                 if valid:
                     valid_signatures.append(valid)
-                    keys = [pub_key for pub_key in keys if pub_key != pub] # Drop public key if valid signature found, to avoid allowing multiple signatures with same key
+                    keys = keys.remove(pub) # Drop public key, to avoid allowing multiple signatures with same key
                     break
             else:
                 valid_signatures.append(False)

--- a/cryptotools/BTC/script.py
+++ b/cryptotools/BTC/script.py
@@ -397,6 +397,7 @@ class VM:
                 valid = sig.verify_hash(sighash, pub)
                 if valid:
                     valid_signatures.append(valid)
+                    [pub_key for pub_key in keys if pub_key != pub] # Drop public key if valid signature found, to avoid allowing multiple signatures with same key
                     break
             else:
                 valid_signatures.append(False)

--- a/cryptotools/BTC/script.py
+++ b/cryptotools/BTC/script.py
@@ -397,7 +397,7 @@ class VM:
                 valid = sig.verify_hash(sighash, pub)
                 if valid:
                     valid_signatures.append(valid)
-                    [pub_key for pub_key in keys if pub_key != pub] # Drop public key if valid signature found, to avoid allowing multiple signatures with same key
+                    keys = [pub_key for pub_key in keys if pub_key != pub] # Drop public key if valid signature found, to avoid allowing multiple signatures with same key
                     break
             else:
                 valid_signatures.append(False)

--- a/cryptotools/BTC/script.py
+++ b/cryptotools/BTC/script.py
@@ -397,7 +397,7 @@ class VM:
                 valid = sig.verify_hash(sighash, pub)
                 if valid:
                     valid_signatures.append(valid)
-                    keys = keys.remove(pub) # Drop public key, to avoid allowing multiple signatures with same key
+                    keys.remove(pub) # Drop public key, to avoid allowing multiple signatures with same key
                     break
             else:
                 valid_signatures.append(False)


### PR DESCRIPTION
Add a single line to drop any public key if that key has a valid signature found in OP_CHECKMULTISIG, this fixes a bug that allows multisig with multiple signatures from a single public key being counted as valid.